### PR TITLE
Feature/32 save user info

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -1,14 +1,19 @@
 import { useEffect, useState } from "react";
 import { getCurrentUser, signOut } from "../supabase/auth";
+import { getUserName } from "../supabase/user";
 
 export function Header() {
-  const [user, setUser] = useState<null | { email: string }>(null);
+  const [user, setUser] = useState<null | { email: string; name: string }>(
+    null,
+  );
 
   useEffect(() => {
     const fetchUser = async () => {
       const currentUser = await getCurrentUser();
-      if (currentUser && currentUser.email) {
-        setUser({ email: currentUser.email });
+      if (currentUser && currentUser.id) {
+        const name = await getUserName(currentUser.id); // UUIDで名前を取得
+        const email = currentUser.email || "不明なメールアドレス"; // デフォルト値を設定
+        setUser({ email: email, name: name || "名無し" });
       } else {
         setUser(null);
       }
@@ -32,7 +37,9 @@ export function Header() {
         <h1 className="text-lg font-bold">My App</h1>
         {user ? (
           <div className="flex items-center space-x-4">
-            <p>ログイン中: {user.email}</p>
+            <p>
+              ログイン中: {user.name} ({user.email})
+            </p>
             <button
               onClick={handleLogout}
               className="bg-red-500 px-4 py-2 rounded hover:bg-red-600"

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -6,10 +6,11 @@ export default function SignupPage() {
   const [password, setPassword] = useState("");
   const [errorMsg, setErrorMsg] = useState("");
   const [successMsg, setSuccessMsg] = useState("");
+  const [name, setName] = useState("");
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const { error } = await signUp(email, password);
+    const { error } = await signUp(email, password, name);
     if (error) {
       setErrorMsg(error.message);
       setSuccessMsg("");
@@ -41,6 +42,17 @@ export default function SignupPage() {
             className="w-full border p-2 rounded"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium">Name</label>
+          <input
+            type="text"
+            className="w-full border p-2 rounded"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
             required
           />
         </div>

--- a/app/supabase/auth.ts
+++ b/app/supabase/auth.ts
@@ -1,6 +1,7 @@
 import { supabase } from "./client";
+import { addUser } from "./user";
 
-export const signUp = async (email: string, password: string) => {
+export const signUp = async (email: string, password: string, name: string) => {
   const { data, error } = await supabase.auth.signUp({
     email,
     password,
@@ -9,6 +10,15 @@ export const signUp = async (email: string, password: string) => {
   if (error) {
     console.error("サインアップ失敗！:", error.message);
     return { error };
+  }
+
+  const user = data.user;
+  if (user) {
+    const { error: dbError } = await addUser(user.id, name);
+    if (dbError) {
+      console.error("ユーザー情報の保存に失敗しました:", dbError.message);
+      return { error: dbError };
+    }
   }
 
   console.log("サインアップ成功:", data);

--- a/app/supabase/user.ts
+++ b/app/supabase/user.ts
@@ -14,7 +14,6 @@ export const addUser = async (uuid: string, name: string) => {
 };
 
 export const getUserName = async (uuid: string) => {
-  console.log(uuid);
   const { data, error } = await supabase
     .from("User")
     .select("user_name")
@@ -25,8 +24,6 @@ export const getUserName = async (uuid: string) => {
     console.error("ユーザー名の取得に失敗しました:", error.message);
     return null;
   }
-
-  console.log(`"取得したデータ:"${data}`);
 
   return data?.user_name || null;
 };

--- a/app/supabase/user.ts
+++ b/app/supabase/user.ts
@@ -1,0 +1,14 @@
+import { supabase } from "./client";
+
+export const addUser = async (uuid: string, name: string) => {
+  const { data, error } = await supabase
+    .from("User")
+    .insert({ uuid: uuid, user_name: name });
+
+  if (error) {
+    console.error("ユーザー情報の保存に失敗💦:", error.message);
+    return { error };
+  }
+  console.log("ユーザー情報を保存しました✨:", data);
+  return { data };
+};

--- a/app/supabase/user.ts
+++ b/app/supabase/user.ts
@@ -12,3 +12,21 @@ export const addUser = async (uuid: string, name: string) => {
   console.log("ユーザー情報を保存しました✨:", data);
   return { data };
 };
+
+export const getUserName = async (uuid: string) => {
+  console.log(uuid);
+  const { data, error } = await supabase
+    .from("User")
+    .select("user_name")
+    .eq("uuid", uuid)
+    .single();
+
+  if (error) {
+    console.error("ユーザー名の取得に失敗しました:", error.message);
+    return null;
+  }
+
+  console.log(`"取得したデータ:"${data}`);
+
+  return data?.user_name || null;
+};


### PR DESCRIPTION
## 内容
- SignUp時に、DBにユーザー情報（uuid, user_name）を追加するaddUser関数
- 現在のuser_nameを取得するgetUserName関数

## 動作確認項目
- npm run dev
- /signUp で名前を登録し、/signIn した際にヘッダーに名前が表示されているか確認
  - この際、すでに登録済みだと名前をうまく登録できないので、supabase上から一度登録したユーザ情報を削除することが望ましい

### テーブルビュー
<img width="957" alt="スクリーンショット 2025-04-22 13 26 25" src="https://github.com/user-attachments/assets/d39415ad-65ec-499a-91e3-72020d7ea4a2" />

### ログイン時にnameを取得したプレビュー
<img width="165" alt="スクリーンショット 2025-04-22 13 34 08" src="https://github.com/user-attachments/assets/a72eafac-9fa3-4561-9c08-64177cc15366" />
