### PR TITLE
Feature/40 if forget password

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 VITE_SUPABASE_URL=https://xxxxx.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-key-here
+
+# VITE_BASE_URL = "本番用"
+VITE_BASE_URL = "http://localhost:5173/"

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -4,4 +4,6 @@ export default [
   index("routes/home.tsx"),
   route("signin", "routes/signin.tsx"),
   route("signup", "routes/signup.tsx"),
+  route("forgot", "routes/forgot.tsx"),
+  route("reset-password", "routes/reset-password.tsx"),
 ] satisfies RouteConfig;

--- a/app/routes/forgot.tsx
+++ b/app/routes/forgot.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import { sendResetPasswordEmail } from "../supabase/auth";
+
+export default function ForgotPassword() {
+  const [email, setEmail] = useState("");
+  const [message, setMessage] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const { error } = await sendResetPasswordEmail(email);
+    if (error) {
+      setMessage("エラーが発生しました。メールアドレスを確認してください。");
+      console.error(error);
+    } else {
+      setMessage("パスワードリセット用のメールを送信しました 📩");
+    }
+  };
+
+  return (
+    <div className="p-4 max-w-md mx-auto">
+      <h1 className="text-xl font-bold mb-4">パスワードをお忘れですか？</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="email"
+          placeholder="メールアドレス"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          className="w-full p-2 border rounded"
+        />
+        <button
+          type="submit"
+          className="w-full bg-blue-600 text-white py-2 rounded"
+        >
+          メールを送信
+        </button>
+        {message && <p className="text-sm mt-2 text-gray-700">{message}</p>}
+      </form>
+    </div>
+  );
+}

--- a/app/routes/forgot.tsx
+++ b/app/routes/forgot.tsx
@@ -19,7 +19,12 @@ export default function ForgotPassword() {
 
   return (
     <div className="p-4 max-w-md mx-auto">
-      <h1 className="text-xl font-bold mb-4">パスワードをお忘れですか？</h1>
+      <h1 className="text-xl font-bold mb-4">パスワードを忘れた場合</h1>
+      <p>
+        ご登録いただいたメールアドレスを入力してください。
+        <br />
+        メールアドレス宛に、パスワード変更ページのURLが記載されたメールを送信します。
+      </p>
       <form onSubmit={handleSubmit} className="space-y-4">
         <input
           type="email"
@@ -33,7 +38,7 @@ export default function ForgotPassword() {
           type="submit"
           className="w-full bg-blue-600 text-white py-2 rounded"
         >
-          メールを送信
+          送信
         </button>
         {message && <p className="text-sm mt-2 text-gray-700">{message}</p>}
       </form>

--- a/app/routes/reset-password.tsx
+++ b/app/routes/reset-password.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import { updatePassword } from "../supabase/auth";
+
+export default function ResetPassword() {
+  const [password, setPassword] = useState("");
+  const [message, setMessage] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const { error } = await updatePassword(password);
+    if (error) {
+      setMessage("パスワードの変更に失敗しました 😢");
+      console.error(error);
+    } else {
+      setMessage("パスワードを変更しました 🎉 ログイン済みです！");
+    }
+  };
+
+  return (
+    <div className="p-4 max-w-md mx-auto">
+      <h1 className="text-xl font-bold mb-4">新しいパスワードを設定</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="password"
+          placeholder="新しいパスワード"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          className="w-full p-2 border rounded"
+        />
+        <button
+          type="submit"
+          className="w-full bg-green-600 text-white py-2 rounded"
+        >
+          パスワード変更
+        </button>
+        {message && <p className="text-sm mt-2 text-gray-700">{message}</p>}
+      </form>
+    </div>
+  );
+}

--- a/app/routes/signin.tsx
+++ b/app/routes/signin.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { signIn } from "../supabase/auth";
+import { Link } from "react-router-dom"; // リンク用のインポートを追加
 
 export default function AuthPage() {
   const [email, setEmail] = useState("");
@@ -51,6 +52,16 @@ export default function AuthPage() {
           ログイン
         </button>
       </form>
+
+      {/* パスワードを忘れた場合の案内を追加 */}
+      <div className="mt-4 text-center">
+        <p className="text-sm text-gray-600">
+          パスワードを忘れた場合は{" "}
+          <Link to="/forgot" className="text-blue-600 hover:underline">
+            こちら
+          </Link>
+        </p>
+      </div>
     </div>
   );
 }

--- a/app/supabase/auth.ts
+++ b/app/supabase/auth.ts
@@ -61,7 +61,7 @@ export const signOut = async () => {
 
 export const sendResetPasswordEmail = async (email: string) => {
   return await supabase.auth.resetPasswordForEmail(email, {
-    redirectTo: "http://localhost:5173/reset-password",
+    redirectTo: `${import.meta.env.VITE_BASE_URL}reset-password`,
   });
 };
 

--- a/app/supabase/auth.ts
+++ b/app/supabase/auth.ts
@@ -58,3 +58,13 @@ export const signOut = async () => {
   console.log("サインアウト成功✨");
   return { success: true };
 };
+
+export const sendResetPasswordEmail = async (email: string) => {
+  return await supabase.auth.resetPasswordForEmail(email, {
+    redirectTo: "http://localhost:5173/reset-password",
+  });
+};
+
+export const updatePassword = async (newPassword: string) => {
+  return await supabase.auth.updateUser({ password: newPassword });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
 				"react": "^19.0.0",
 				"react-dom": "^19.0.0",
 				"react-resizable-panels": "^2.1.7",
-				"react-router": "^7.5.0"
+				"react-router": "^7.5.0",
+				"react-router-dom": "^7.5.1"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^1.9.4",
@@ -8903,6 +8904,22 @@
 				"react-dom": ">=17",
 				"react-router": ">=7.0.0",
 				"vite": ">=5.0.0 || >=6.0.0"
+			}
+		},
+		"node_modules/react-router-dom": {
+			"version": "7.5.1",
+			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.5.1.tgz",
+			"integrity": "sha512-5DPSPc7ENrt2tlKPq0FtpG80ZbqA9aIKEyqX6hSNJDlol/tr6iqCK4crqdsusmOSSotq6zDsn0y3urX9TuTNmA==",
+			"license": "MIT",
+			"dependencies": {
+				"react-router": "7.5.1"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=18",
+				"react-dom": ">=18"
 			}
 		},
 		"node_modules/react-router/node_modules/cookie": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
 		"react": "^19.0.0",
 		"react-dom": "^19.0.0",
 		"react-resizable-panels": "^2.1.7",
-		"react-router": "^7.5.0"
+		"react-router": "^7.5.0",
+		"react-router-dom": "^7.5.1"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",


### PR DESCRIPTION
## 内容
- /signupに「パスワードを忘れた場合はこちら」の案内を追加
- /forgotで再設定用のメールを送信するsendResetPasswordEmail関数を追加
- メールに送られるリンク先にて、パスワードを変更するupdatePassword関数を追加
- .envでURLを管理するように変更、本番環境に楽に切り替えられるようにしたい

## 動作確認項目
- `npm run dev`
- /signin で「パスワードを忘れた場合はこちら」へ
- 登録済みメールアドレスを入力
- メールのリンクからパスワードを再設定
- 再設定後、再度ログインしてみる